### PR TITLE
add support for `Cache-Control` = `no-cache` and `no-store`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ expire | int, states a caching time in seconds
 namespace | str, namespace to use to store certain cache items
 coder | which coder to use, e.g. JsonCoder
 key_builder | which key builder to use, default to builtin
+allow_client_caching | the `response` should allow the caller to cache (default to False)
 
 You can also use `cache` as decorator like other cache tools to cache common function result.
 
@@ -143,6 +144,10 @@ async def index():
 `InMemoryBackend` store cache data in memory and use lazy delete, which mean if you don't access it after cached, it
 will not delete automatically.
 
+### No-Store-Response
+For certain content, we want to handle all caching at the server (e.g. so we can do automatic invalidation) so
+this flag instructs the client (i.e. Browser/app) not to do any local caching
+
 ## Headers
 
 ### Cache-Control (Request)
@@ -160,7 +165,12 @@ If the `if-none-match` header is set on the request, then FastAPI-Cache will ret
 response if a cached result is found and its `ETag` value matches the `ETag` header.
 
 ### Cache-Control (Response)
-The `Cache-Control: max-age=SSSS` header will be returned if the result can be cached by the caller
+Because we want to handle cache invalidation with server-side logic, by default the response will
+return `Cache-Control: no-store` indicating that the client should always check the server for fresh
+results.
+
+If 'allow_client_caching' is set, the `Cache-Control: max-age=####` header will be returned instead.
+
 
 ### X-Cache-Hit (Response)
 FastAPI-Cache will return a `X-Cache-Hit: True` header if the response is served from the cache

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fastapi-cache
+# fastapi-cache - fork for Playfully
 
 ![pypi](https://img.shields.io/pypi/v/fastapi-cache2.svg?style=flat)
 ![license](https://img.shields.io/github/license/long2ice/fastapi-cache)
@@ -142,6 +142,32 @@ async def index():
 
 `InMemoryBackend` store cache data in memory and use lazy delete, which mean if you don't access it after cached, it
 will not delete automatically.
+
+## Headers
+
+### Cache-Control (Request)
+The `Cache-Control` header can be used in a GET Request to control the behavior of the cache:
+
+* If `Cache-Control: no-store` is set on the request, then FastAPI-Cache will return a fresh result
+  and will not store that result. However, an existing cache will not be removed, so the next request
+  may still return the cached result.
+* If `Cache-Control: no-cache` is set on the request, then FastAPI-Cache will generate a fresh result
+  and will store that result (overwriting the cache if necessary)
+* These two headers are mutually exclusive
+
+### if-none-match (Request)
+If the `if-none-match` header is set on the request, then FastAPI-Cache will return an `HTTP_304: Not Modified`
+response if a cached result is found and its `ETag` value matches the `ETag` header.
+
+### Cache-Control (Response)
+The `Cache-Control: max-age=SSSS` header will be returned if the result can be cached by the caller
+
+### X-Cache-Hit (Response)
+FastAPI-Cache will return a `X-Cache-Hit: True` header if the response is served from the cache
+
+### ETag (Response)
+FastAPI-Cache will return an `ETag` header if the result can be cached by the caller
+
 
 ## Tests and coverage
 

--- a/README.md
+++ b/README.md
@@ -144,9 +144,12 @@ async def index():
 `InMemoryBackend` store cache data in memory and use lazy delete, which mean if you don't access it after cached, it
 will not delete automatically.
 
-### No-Store-Response
-For certain content, we want to handle all caching at the server (e.g. so we can do automatic invalidation) so
-this flag instructs the client (i.e. Browser/app) not to do any local caching
+### Allow-Client-Caching
+For certain content, we want to handle all caching at the server (e.g. so we can do automatic
+invalidation, e.g. when the user profile changes so cached shortlists are no longer valid)
+so this flag instructs the client (i.e. Browser/app) not to do any local caching. If content is
+relatively stable, it can be overridden with the `allow_client_caching` parameter inside the `@cache()`
+decorator.
 
 ## Headers
 

--- a/examples/in_memory/main.py
+++ b/examples/in_memory/main.py
@@ -42,13 +42,16 @@ async def get_date():
 async def get_datetime(request: Request, response: Response):
     return {"now": pendulum.now()}
 
+
 @cache(namespace="test")
 async def func_kwargs(*unused_args, **kwargs):
     return kwargs
 
+
 @app.get("/kwargs")
 async def get_kwargs(name: str):
     return await func_kwargs(name, name=name)
+
 
 @app.get("/sync-me")
 @cache(namespace="test")
@@ -56,6 +59,12 @@ def sync_me():
     # as per the fastapi docs, this sync function is wrapped in a thread,
     # thereby converted to async. fastapi-cache does the same.
     return 42
+
+
+@app.get("/client-side-cacheable")
+@cache(namespace="test", expire=2, allow_client_caching=True)
+async def no_store(request: Request, response: Response):
+    return {"now": pendulum.now()}
 
 
 @app.get("/cache_response_obj")

--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -3,6 +3,7 @@ import logging
 import sys
 from functools import wraps
 from typing import Any, Awaitable, Callable, Optional, Type, TypeVar
+from fastapi.exceptions import HTTPException
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
@@ -105,9 +106,16 @@ def cache(
             copy_kwargs = kwargs.copy()
             request: Optional[Request] = copy_kwargs.pop("request", None)
             response: Optional[Response] = copy_kwargs.pop("response", None)
-            if (
-                request and request.headers.get("Cache-Control") in ("no-store", "no-cache")
-            ) or not FastAPICache.get_enable():
+            # Cache-Control: no-store means do not store the result
+            # Cache-Control: no-cache means retrieve a fresh result AND store it
+            # Cache-Control: no-store and Cache-Control: no-cache are mutually exclusive
+            no_store = request and request.headers.get("Cache-Control") in ["no-store"]
+            no_cache = request and request.headers.get("Cache-Control") in ["no-cache"]
+            if no_store or not FastAPICache.get_enable():
+                logger.debug("Cache disabled due to Cache-Control:no-store")
+                return await ensure_async_func(*args, **kwargs)
+            # Only use a cache for GET requests (no POST/PUT/etc.)
+            if request and request.method != "GET":
                 return await ensure_async_func(*args, **kwargs)
 
             coder = coder or FastAPICache.get_coder()
@@ -133,50 +141,63 @@ def cache(
                     args=args,
                     kwargs=copy_kwargs,
                 )
-            try:
-                ttl, ret = await backend.get_with_ttl(cache_key)
-            except Exception:
-                logger.warning(f"Error retrieving cache key '{cache_key}' from backend:", exc_info=True)
-                ttl, ret = 0, None
-            if not request:
-                if ret is not None:
-                    return coder.decode(ret)
+
+            # if no_cache, ensure a fresh result, otherwise check cache
+            cache_hit = False
+            ttl = 0
+            etag = ""
+            if no_cache:
                 ret = await ensure_async_func(*args, **kwargs)
+            else:
                 try:
-                    await backend.set(cache_key, coder.encode(ret), expire)
+                    ttl, encoded_ret = await backend.get_with_ttl(cache_key)
+                    if encoded_ret is None:
+                        logger.debug(f"Cache miss for key '{cache_key}'")
+                        ret = await ensure_async_func(*args, **kwargs)
+                    else:
+                        logger.debug(f"Cache hit for key '{cache_key}'")
+                        cache_hit = True
+                        ret = coder.decode(encoded_ret)
+                        etag = f"W/{hash(encoded_ret)}"
+
                 except Exception:
-                    logger.warning(f"Error setting cache key '{cache_key}' in backend:", exc_info=True)
+                    logger.warning(
+                        f"Error retrieving cache key '{cache_key}' from backend:", exc_info=True
+                    )
+                    ret = await ensure_async_func(*args, **kwargs)
+
+            # if we DIDN'T read from cache, then we should store
+            if cache_hit is False:
+                try:
+                    encoded_ret = coder.encode(ret)
+                    await backend.set(cache_key, encoded_ret, expire)
+                except Exception:
+                    logger.warning(
+                        f"Error setting cache key '{cache_key}' in backend:", exc_info=True
+                    )
+
+            # Now we need to return something. If it's an internal method
+            # then no further processing is needed
+            if not request:
                 return ret
 
-            if request.method != "GET":
-                return await ensure_async_func(request, *args, **kwargs)
-
-            if_none_match = request.headers.get("if-none-match")
-            if ret is not None:
-                if response:
+            # Otherwise, we optionally need some headers
+            if response:
+                if cache_hit:
                     response.headers["Cache-Control"] = f"max-age={ttl}"
-                    etag = f"W/{hash(ret)}"
-                    if if_none_match == etag:
-                        response.status_code = 304
-                        return response
                     response.headers["ETag"] = etag
-                return coder.decode(ret)
+                    response.headers["X-Cache-Hit"] = "True"
+                    # The If-None-Match HTTP request header makes the request
+                    # conditional, returning a 304 status if the ETag matches
+                    # something in the cache
+                    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match
+                    if request and etag == request.headers.get("if-none-match"):
+                        raise HTTPException(status_code=304, headers={"ETag": etag})
+                else:
+                    response.headers["Cache-Control"] = f"max-age={expire}"
+                    response.headers["ETag"] = f"W/{hash(coder.encode(ret))}"
 
-            ret = await ensure_async_func(*args, **kwargs)
-            encoded_ret = coder.encode(ret)
-
-            try:
-                await backend.set(cache_key, encoded_ret, expire)
-            except Exception:
-                logger.warning(f"Error setting cache key '{cache_key}' in backend:", exc_info=True)
-
-            if response is not None:
-                # if called outside a Request/Response context, these headers
-                # aren't needed anyway
-                response.headers["Cache-Control"] = f"max-age={expire}"
-                etag = f"W/{hash(encoded_ret)}"
-                response.headers["ETag"] = etag
-            return ret
+                return ret
 
         return inner
 

--- a/fastapi_cache/key_builder.py
+++ b/fastapi_cache/key_builder.py
@@ -18,8 +18,6 @@ def default_key_builder(
     prefix = f"{FastAPICache.get_prefix()}:{namespace}:"
     cache_key = (
         prefix
-        + hashlib.md5(  # nosec:B303
-            f"{func.__module__}:{func.__name__}:{args}:{kwargs}".encode()
-        ).hexdigest()
+        + hashlib.blake2b(f"{func.__module__}:{func.__name__}:{args}:{kwargs}".encode()).hexdigest()
     )
     return cache_key

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -76,7 +76,7 @@ def test_kwargs() -> None:
         assert response.json() == {"name": name}
 
 
-def test_cache_control_nostore() -> None:
+def test_cache_control_no_store() -> None:
     with TestClient(app) as client:
         # Cache-Control: no-store should return a fresh result that is not stored,
         # so two hits within the cache TTL should be different, and then
@@ -101,7 +101,7 @@ def test_cache_control_nostore() -> None:
         assert response.headers.get("X-Cache-Hit") != "True"
 
 
-def test_cache_control_nocache() -> None:
+def test_cache_control_no_cache() -> None:
     with TestClient(app) as client:
         # Cache-Control: no-cache should force a fresh result to be returned
         # AND stored
@@ -141,3 +141,14 @@ def test_cache_control_etag() -> None:
         etag = "foo"
         response = client.get("/datetime", headers={"if-none-match": etag})
         assert response.status_code == 200
+
+
+def test_client_caching() -> None:
+    with TestClient(app) as client:
+        # Cache-Control: no-store should be returned from this endpoint
+        response = client.get("/client-side-cacheable")
+        assert response.headers.get("cache-control") != "no-store"
+        assert "max-age" in response.headers.get("cache-control")
+
+        response = client.get("/datetime")
+        assert response.headers.get("cache-control") == "no-store"


### PR DESCRIPTION
This PR adds/improves support for the `Cache-Control` header in our private fork of FastAPI-Cache.

Specifically, it adds cache overwriting to the `no-cache` Request header, which is underspecified in the W3C spec.

MDN says

> `no-cache`
> The no-cache request directive asks caches to validate the response with the origin server before reuse.
> `no-cache` allows clients to request the most up-to-date response even if the cache has a [fresh](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age) response.
> 
> Browsers usually add no-cache to requests when users are force reloading a page.

Therefore I feel like using this directive to overwrite the cache is logical. 

Furthermore, this PR clarifies that the `Cache-Control: no-store` directive should return a fresh result, in addition to not storing the result.  Previously, these two directives were both handled the same (neither read nor write to cache)

This modified behavior could allow a rogue client to DOS the cache, but since the previous implementation already allowed DOSing the server itself, this doesn't feel like a material new risk. 

This PR also adds new unit tests to verify the logic; run with `pytest -v`